### PR TITLE
Refactor/randomize first player

### DIFF
--- a/game.js
+++ b/game.js
@@ -34,7 +34,7 @@ class Game {
     }
   }
 
-  updateCurrentGameData(keyName, playerId) {
+  updateGameData(keyName, playerId) {
     this.currentGameData[keyName] = playerId;
   }
 

--- a/main.js
+++ b/main.js
@@ -42,7 +42,7 @@ function checkIfEmptySquare(e) {
 
 function placePlayerToken(targetSquare) {
   var targetSquareNumber = targetSquare.classList[1];
-  game.updateCurrentGameData(targetSquareNumber, game.currentPlayer.id);
+  game.updateGameData(targetSquareNumber, game.currentPlayer.id);
   targetSquare.innerHTML = `<img src=${game.currentPlayer.token} alt="${game.currentPlayer.id} icon">`;
   targetSquare.classList.remove('hover');
 };


### PR DESCRIPTION
Changed the functionality so that the starting player upon page refresh is random instead of always player one: millstone. From then on out until the next refresh, it rotates turns.

Renamed two functions to be more accurate / shorter.